### PR TITLE
chore: ensure ViewModel is disposed when page tears down

### DIFF
--- a/src/UI/Features/Components/ScreenBase.cs
+++ b/src/UI/Features/Components/ScreenBase.cs
@@ -69,6 +69,7 @@ public abstract class ScreenBase<T> : ReactiveContentPage<T>, IInitializeAsync, 
     private void TearDown()
     {
         Garbage.Dispose();
+        ViewModel?.Dispose();
         Destroy();
     }
 }

--- a/src/UI/Features/FeaturesModule.cs
+++ b/src/UI/Features/FeaturesModule.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Net.Http;
 using DryIoc;
 using MediatR;

--- a/test/Rx.Tracker.Tests/Container/ContainerFixture.cs
+++ b/test/Rx.Tracker.Tests/Container/ContainerFixture.cs
@@ -7,12 +7,7 @@ using Rocket.Surgery.Extensions.Testing;
 using Rocket.Surgery.Extensions.Testing.Fixtures;
 using Rx.Tracker.Container;
 using Rx.Tracker.Mediation;
-using Rx.Tracker.Mediation.Commands;
-using Rx.Tracker.Mediation.Queries;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 
 namespace Rx.Tracker.Tests.Container;
 


### PR DESCRIPTION
clean up namespaces
